### PR TITLE
V init: Add all prompts as flags as well

### DIFF
--- a/doc/docs.md
+++ b/doc/docs.md
@@ -66,7 +66,7 @@ by using any of the following commands in a terminal:
 * [Variables](#variables)
     * [Mutable variables](#mutable-variables)
     * [Initialization vs assignment](#initialization-vs-assignment)
-    * [Declaration errors](#declaration-errors)
+    * [Warnings and declaration errors](#warnings-and-declaration-errors)
 * [V types](#v-types)
     * [Primitive types](#primitive-types)
     * [Strings](#strings)
@@ -444,25 +444,42 @@ a, b = b, a
 println('${a}, ${b}') // 1, 0
 ```
 
-### Declaration errors
+### Warnings and declaration errors
 
 In development mode the compiler will warn you that you haven't used the variable
 (you'll get an "unused variable" warning).
 In production mode (enabled by passing the `-prod` flag to v – `v -prod foo.v`)
 it will not compile at all (like in Go).
+```v
+fn main() {
+	a := 10
+	// warning: unused variable `a`
+}
+```
 
+To ignore values returned by a function `_` can be used
+```v
+fn foo() (int, int) {
+	return 2, 3
+}
+
+fn main() {
+	c, _ := foo()
+	print(c)
+	// no warning about unused variable returned by foo.
+}
+```
+
+Unlike most languages, variable shadowing is not allowed. Declaring a variable with a name
+that is already used in a parent scope will cause a compilation error.
 ```v failcompile nofmt
 fn main() {
 	a := 10
 	if true {
 		a := 20 // error: redefinition of `a`
 	}
-	// warning: unused variable `a`
 }
 ```
-
-Unlike most languages, variable shadowing is not allowed. Declaring a variable with a name
-that is already used in a parent scope will cause a compilation error.
 
 ## V Types
 

--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -2305,7 +2305,11 @@ fn (mut g Gen) keep_alive_call_postgen(node ast.CallExpr, tmp_cnt_save int) {
 
 @[inline]
 fn (mut g Gen) ref_or_deref_arg(arg ast.CallArg, expected_type ast.Type, lang ast.Language) {
-	arg_typ := g.unwrap_generic(arg.typ)
+	arg_typ := if arg.expr is ast.ComptimeSelector {
+		g.unwrap_generic(g.comptime.get_comptime_var_type(arg.expr))
+	} else {
+		g.unwrap_generic(arg.typ)
+	}
 	arg_sym := g.table.sym(arg_typ)
 	exp_is_ptr := expected_type.is_any_kind_of_pointer()
 	arg_is_ptr := arg_typ.is_any_kind_of_pointer()

--- a/vlib/v/tests/comptime_deref_or_ref_test.v
+++ b/vlib/v/tests/comptime_deref_or_ref_test.v
@@ -1,0 +1,41 @@
+pub struct Association {
+	price       string
+	association &Association = unsafe { nil }
+}
+
+// needed to check the condition for #20400
+fn myprintln(s string) string {
+	println('---------> ${s}')
+	return s
+}
+
+fn encode_struct[U](a U) {
+	mut c := 0
+	$for field in U.fields {
+		$if field.name == 'association' {
+			x := myprintln(ptr_str(a.$(field.name)))
+			println(field.name)
+			c += 1
+			assert ptr_str(a.$(field.name)) == '0'
+		} $else {
+			println(field.name)
+			c += 1
+			assert ptr_str(a.$(field.name)) != '0'
+		}
+		x := myprintln(ptr_str(a.$(field.name)))
+		if field.name == 'association' {
+			dump(x)
+			assert x == '0'
+		}
+	}
+	dump(c)
+	assert c == 2
+}
+
+fn test_main() {
+	a := Association{}
+
+	assert ptr_str(a.price) != '0'
+	assert ptr_str(a.association) == '0'
+	encode_struct(a)
+}

--- a/vlib/vweb/vweb.v
+++ b/vlib/vweb/vweb.v
@@ -240,26 +240,26 @@ pub fn (mut ctx Context) send_response_to_client(mimetype string, res string) bo
 	return true
 }
 
-// Response HTTP_OK with payload with content-type `text/html`
+// Response with payload and content-type `text/html`
 pub fn (mut ctx Context) html(payload string) Result {
 	ctx.send_response_to_client('text/html', payload)
 	return Result{}
 }
 
-// Response HTTP_OK with s as payload with content-type `text/plain`
+// Response with s as payload and content-type `text/plain`
 pub fn (mut ctx Context) text(s string) Result {
 	ctx.send_response_to_client('text/plain', s)
 	return Result{}
 }
 
-// Response HTTP_OK with json_s as payload with content-type `application/json`
+// Response with json_s as payload and content-type `application/json`
 pub fn (mut ctx Context) json[T](j T) Result {
 	json_s := json.encode(j)
 	ctx.send_response_to_client('application/json', json_s)
 	return Result{}
 }
 
-// Response HTTP_OK with a pretty-printed JSON result
+// Response with a pretty-printed JSON result
 pub fn (mut ctx Context) json_pretty[T](j T) Result {
 	json_s := json.encode_pretty(j)
 	ctx.send_response_to_client('application/json', json_s)
@@ -267,7 +267,7 @@ pub fn (mut ctx Context) json_pretty[T](j T) Result {
 }
 
 // TODO - test
-// Response HTTP_OK with file as payload
+// Response with file as payload
 pub fn (mut ctx Context) file(f_path string) Result {
 	if !os.exists(f_path) {
 		eprintln('[vweb] file ${f_path} does not exist')
@@ -289,8 +289,9 @@ pub fn (mut ctx Context) file(f_path string) Result {
 	return Result{}
 }
 
-// Response HTTP_OK with s as payload
+// Response with s as payload and sets the status code to HTTP_OK
 pub fn (mut ctx Context) ok(s string) Result {
+	ctx.set_status(200, 'OK')
 	ctx.send_response_to_client(ctx.content_type, s)
 	return Result{}
 }


### PR DESCRIPTION
## PR adds

Flags on `v init`:

```
--description (if '' - empty string, then it's gonna prompt)
--project-version (--version conflicted with v's version, default: 0.0.0)
--license (default: MIT)
```

## Reason / What it fixes:

As a user, I wanted to make a quick bin/sh command that would auto-create a project with `v` without any prompts, I wanted all to be automatically and the prompts would auto-fill themselves with the information I already had from the script. But prompts preventing that. 

Even if there is another way, it feels much more straightforward to just have the prompts accessible as flags, so the user can notice them immediately.

Reason for closing:
------

Sorry, I synced the branch by mistake on my fork, so I took the commits of other people as well as part of my PR.